### PR TITLE
Remove secrets inheritance for cross-repository workflow compatibility

### DIFF
--- a/.github/workflows/version-management.yml
+++ b/.github/workflows/version-management.yml
@@ -27,7 +27,6 @@ on:
         default: true
         type: boolean
         
-    secrets: inherit
 
     outputs:
       has-changesets:


### PR DESCRIPTION
## Summary
Removes the `secrets: inherit` declaration from the version-management workflow to ensure cross-repository compatibility when called from external repositories.

## Changes

**Workflow Configuration Fix**
- **Removed**: `secrets: inherit` line from `.github/workflows/version-management.yml`
- **Impact**: The workflow will no longer automatically inherit all secrets from calling workflows, requiring explicit secret passing instead
- **Compatibility**: Fixes issues when this reusable workflow is called from different repositories that may not have the same secret names or want to control which secrets are accessible
- **Best Practice**: Aligns with GitHub Actions security best practices by making secret access explicit rather than implicit

This is a breaking change that will require calling workflows to explicitly pass any needed secrets as parameters rather than relying on automatic inheritance.

---
🤖 Generated with gprc made by Walid + Claude