### PR TITLE
Add missing checkout step to changesets PR merge action

### DIFF
--- a/actions/release/changesets-pr-merge/action.yml
+++ b/actions/release/changesets-pr-merge/action.yml
@@ -91,6 +91,13 @@ runs:
       env:
         GITHUB_TOKEN: ${{ inputs.github-token }}
 
+    - name: Checkout repository
+      if: steps.wait-merge.outputs.merged == 'true'
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+        token: ${{ inputs.github-token }}
+
     - name: Checkout main and create tag
       id: create-tag
       if: steps.wait-merge.outputs.merged == 'true'


### PR DESCRIPTION
## Summary
Fix missing checkout step in the changesets-pr-merge action that was preventing tag creation after PR merge.

## Changes

**Bug Fix - Missing Repository Checkout:**
- Added essential `actions/checkout@v4` step before tag creation in `actions/release/changesets-pr-merge/action.yml:94-101`
- Checkout only executes when PR is successfully merged (`steps.wait-merge.outputs.merged == 'true'`)
- Uses full git history (`fetch-depth: 0`) required for proper tag creation
- Uses the provided GitHub token for authentication to ensure proper permissions

**Technical Context:**
The action was attempting to create git tags without first checking out the repository code, which would cause the tag creation step to fail. This fix ensures the repository is available in the runner before attempting git operations.

---
🤖 Generated with gprc made by Walid + Claude