### PR TITLE
Fix www subdomain DNS configuration to point to correct Railway target

### DIFF
--- a/.github/workflows/dns.yml
+++ b/.github/workflows/dns.yml
@@ -68,9 +68,8 @@ jobs:
     name: Update DNS
     runs-on: ubuntu-latest
     outputs:
-      success: ${{ steps.cloudflare.outputs.success == 'true' && steps.cloudflare-www.outputs.success == 'true' }}
+      success: ${{ steps.cloudflare.outputs.success == 'true' }}
       record-id: ${{ steps.cloudflare.outputs.record-id }}
-      www-record-id: ${{ steps.cloudflare-www.outputs.record-id }}
     steps:
       - name: Update Cloudflare DNS
         id: cloudflare
@@ -224,14 +223,14 @@ jobs:
             exit 1
           fi
           
-          # Add www subdomain (CNAME to main domain)
+          # Add www subdomain (CNAME to same Railway target)
           if [[ "${{ inputs.domain }}" != www.* ]]; then
-            echo "Adding www.${{ inputs.domain }} CNAME..."
+            echo "Adding www.${{ inputs.domain }} CNAME to same target..."
             
             WWW_DATA=$(jq -n \
               --arg type "CNAME" \
               --arg name "www.${{ inputs.domain }}" \
-              --arg content "${{ inputs.domain }}" \
+              --arg content "$TARGET_VALUE" \
               --argjson proxied true \
               --argjson ttl 1 \
               '{type: $type, name: $name, content: $content, proxied: $proxied, ttl: $ttl}')


### PR DESCRIPTION
## Summary
Fixes www subdomain CNAME record to point directly to Railway deployment target instead of the main domain.

## Changes

### DNS Configuration Fix
- **CNAME Target Correction**: Changed www subdomain CNAME from pointing to `${{ inputs.domain }}` to pointing directly to `$TARGET_VALUE` (Railway deployment URL)
- **Workflow Output Simplification**: Removed www-specific success tracking and record ID output since www subdomain is now handled within the same DNS update step
- **Comment Update**: Updated inline comment to reflect that www subdomain now points to "same Railway target" rather than "main domain"

### Technical Impact
- **Eliminates DNS redirect loop**: Previously www.domain.com → domain.com → Railway target, now www.domain.com → Railway target directly
- **Reduces DNS lookup hops**: Improves performance by removing unnecessary DNS resolution step
- **Simplifies workflow outputs**: Consolidates success tracking into single boolean instead of AND operation between main and www records

This change ensures both the apex domain and www subdomain point directly to the Railway deployment, following DNS best practices for CNAME records.

---
🤖 Generated with gprc made by Walid + Claude