### PR TITLE
Fix null result handling in Cloudflare SEO automation

### DIFF
--- a/actions/seo/cloudflare-seo-setup/action.yml
+++ b/actions/seo/cloudflare-seo-setup/action.yml
@@ -118,7 +118,7 @@ runs:
           EXISTING_RULE=$(curl -s -X GET "https://api.cloudflare.com/client/v4/zones/$CF_ZONE_ID/pagerules" \
             -H "Authorization: Bearer $CF_API_TOKEN" \
             -H "Content-Type: application/json" | \
-            jq -r --arg pattern "$url_pattern" '.result[] | select(.targets[0].target.url==$pattern) | .id // empty')
+            jq -r --arg pattern "$url_pattern" '.result // [] | .[] | select(.targets[0].target.url==$pattern) | .id // empty')
           
           if [[ -n "$EXISTING_RULE" ]]; then
             echo "  • ♻️  Updating existing rule: $EXISTING_RULE"
@@ -199,7 +199,7 @@ runs:
           EXISTING_REDIRECT=$(curl -s -X GET "https://api.cloudflare.com/client/v4/zones/$CF_ZONE_ID/pagerules" \
             -H "Authorization: Bearer $CF_API_TOKEN" \
             -H "Content-Type: application/json" | \
-            jq -r --arg pattern "$from_pattern" '.result[] | select(.targets[0].target.url==$pattern and (.actions[0].id=="forwarding_url" or .actions[0].id=="redirect")) | .id // empty')
+            jq -r --arg pattern "$from_pattern" '.result // [] | .[] | select(.targets[0].target.url==$pattern and (.actions[0].id=="forwarding_url" or .actions[0].id=="redirect")) | .id // empty')
           
           REDIRECT_SETTINGS='[{
             "id": "forwarding_url",


### PR DESCRIPTION
## Summary
Fixed JSON processing error in Cloudflare SEO action by adding null safety to handle missing or null `result` field in API responses.

## Changes

**Bug Fix - Null Safety Enhancement:**
- **File**: `actions/seo/cloudflare-seo-setup/action.yml`
- **Issue**: The jq filter `.result[]` would fail when the `result` field is `null` or missing in Cloudflare API responses
- **Solution**: Changed `.result[]` to `.result // [] | .[]` in two locations (lines 121 and 202)
- **Impact**: 
  - Prevents jq errors when Cloudflare API returns empty or malformed responses
  - Provides fallback empty array when `result` field is null/undefined
  - Maintains existing functionality for valid responses while adding resilience to edge cases

**Technical Details:**
- The fix uses jq's alternative operator (`//`) to provide an empty array fallback
- Affects both existing page rule detection and redirect rule detection logic
- No functional changes to the action's behavior when API responses are valid

---
🤖 Generated with gprc made by Walid + Claude